### PR TITLE
Prevent default hotkey behaviour when component selected

### DIFF
--- a/src/Editor.js
+++ b/src/Editor.js
@@ -313,8 +313,12 @@ const Editor = () => {
     doc.layers.filter(layer => view.selection.has(layer.id))
   );
   const keys = useKeys({
-    keydown: ({ code }) => {
-      switch (code) {
+    keydown: (event) => {
+      const codeBlacklist = set(["Backspace", "ShiftLeft", "ShiftRight", "ArrowLeft", "ArrowUp", "ArrowRight", "ArrowDown"])
+      if ((state.view.selection.size > 0 || event.code === "Backspace") && codeBlacklist.has(event.code)) {
+        event.preventDefault()
+      }
+      switch (event.code) {
         case "ArrowLeft":
           transformSelection({
             x: Math.round(selectionBounds.x1) - (keys.has("ShiftLeft") || keys.has("ShiftRight") ? 10 : 1)

--- a/src/Editor.js
+++ b/src/Editor.js
@@ -321,10 +321,21 @@ const Editor = () => {
     doc.layers.filter(layer => view.selection.has(layer.id))
   );
   const keys = useKeys({
-    keydown: (event) => {
-      const codeBlacklist = set(["Backspace", "ShiftLeft", "ShiftRight", "ArrowLeft", "ArrowUp", "ArrowRight", "ArrowDown"])
-      if ((state.view.selection.size > 0 || event.code === "Backspace") && codeBlacklist.has(event.code)) {
-        event.preventDefault()
+    keydown: event => {
+      const codeBlacklist = set([
+        "Backspace",
+        "ShiftLeft",
+        "ShiftRight",
+        "ArrowLeft",
+        "ArrowUp",
+        "ArrowRight",
+        "ArrowDown"
+      ]);
+      if (
+        (state.view.selection.size > 0 || event.code === "Backspace") &&
+        codeBlacklist.has(event.code)
+      ) {
+        event.preventDefault();
       }
       switch (event.code) {
         case "ArrowLeft":


### PR DESCRIPTION
Fixes #39

I'm not sure what the hotkeys are like in figma and other services used by designers but here is my solution and I guess you can add or subtract some keys from the array based on what you think makes sense.

Also, it's worth noting that when typing in an input, backspace still works as usual in this implementation