### PR TITLE
Cli fix

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const process = require("process");
 const path = require("path");
 const fs = require("fs-extra");

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sketchbook-js",
   "version": "0.1.0",
   "private": true,
-  "bin": "cli/index.js",
+  "bin" : { "sketchbook" : "cli/index.js" },
   "scripts": {
     "build": "node scripts/build",
     "eslint:fix": "eslint --fix src/**.js",


### PR DESCRIPTION
Fixes #98, fixes #99

I tested #99 by following your instructions on the issue. That error does not show up anymore.

I tackled #100 by using npmignore and not including the build directory in it and have [tested it](https://docs.npmjs.com/cli/v6/using-npm/developers#testing-whether-your-npmignore-or-files-config-works). The build directory now shows up when I pack it.

#100 will be handled in another PR as detailed below